### PR TITLE
fix: use values for init container images instead of hardcoded refere…

### DIFF
--- a/phase-console/templates/_helpers.tpl
+++ b/phase-console/templates/_helpers.tpl
@@ -90,7 +90,7 @@ Used by backend, worker, and frontend to ensure migrations complete before the m
 */}}
 {{- define "phase.waitForMigrations" -}}
 - name: wait-for-migrations
-  image: postgres:15.4-alpine3.17
+  image: "{{ .Values.database.image.repository }}:{{ .Values.database.image.tag }}"
   command: ['sh', '-c', 'echo "Waiting for database migrations to complete..."; until psql -h {{ tpl .Values.database.host . }} -p {{ .Values.database.port }} -U {{ .Values.database.user }} -d {{ .Values.database.name }} -c "SELECT 1 FROM django_migrations LIMIT 1;" >/dev/null 2>&1; do echo "Migrations pending - sleeping 5s"; sleep 5; done; echo "Migrations complete!"']
   securityContext:
     allowPrivilegeEscalation: false

--- a/phase-console/templates/deployment-worker.yaml
+++ b/phase-console/templates/deployment-worker.yaml
@@ -32,7 +32,7 @@ spec:
       initContainers:
       {{- include "phase.waitForMigrations" . | nindent 6 }}
       - name: wait-for-redis
-        image: redis:alpine3.19
+        image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
         command: ['sh', '-c', 'echo "Waiting for Redis at {{ tpl .Values.redis.host . }}:{{ .Values.redis.port }}..."; AUTH_ARGS=""; {{- if .Values.redis.user }} AUTH_ARGS="--user \"${REDIS_USER}\""; {{- end }} until redis-cli -h {{ tpl .Values.redis.host . }} -p {{ .Values.redis.port }}{{- if .Values.redis.ssl }} --tls{{- end }} $AUTH_ARGS -a "$REDIS_PASSWORD" ping 2>/dev/null || redis-cli -h {{ tpl .Values.redis.host . }} -p {{ .Values.redis.port }}{{- if .Values.redis.ssl }} --tls{{- end }} $AUTH_ARGS ping; do echo "Redis is unavailable - sleeping 5s"; sleep 5; done; echo "Redis is ready!"']
         securityContext:
           allowPrivilegeEscalation: false

--- a/phase-console/templates/job-migrations.yaml
+++ b/phase-console/templates/job-migrations.yaml
@@ -33,7 +33,7 @@ spec:
         {{- toYaml .Values.securityContext.pod | nindent 8 }}
       initContainers:
       - name: wait-for-redis
-        image: redis:alpine3.19
+        image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
         command: ['sh', '-c', 'echo "Waiting for Redis at {{ tpl .Values.redis.host . }}:{{ .Values.redis.port }}..."; AUTH_ARGS=""; {{- if .Values.redis.user }} AUTH_ARGS="--user \"${REDIS_USER}\""; {{- end }} until redis-cli -h {{ tpl .Values.redis.host . }} -p {{ .Values.redis.port }}{{- if .Values.redis.ssl }} --tls{{- end }} $AUTH_ARGS -a "$REDIS_PASSWORD" ping 2>/dev/null || redis-cli -h {{ tpl .Values.redis.host . }} -p {{ .Values.redis.port }}{{- if .Values.redis.ssl }} --tls{{- end }} $AUTH_ARGS ping; do echo "Redis is unavailable - sleeping 5s"; sleep 5; done; echo "Redis is ready!"']
         securityContext:
           allowPrivilegeEscalation: false
@@ -51,7 +51,7 @@ spec:
           value: {{ .Values.redis.user | quote }}
         {{- end }}
       - name: check-db-ready
-        image: postgres:15.4-alpine3.17
+        image: "{{ .Values.database.image.repository }}:{{ .Values.database.image.tag }}"
         command: ['sh', '-c',
           'echo "Waiting for database at {{ tpl .Values.database.host . }}:{{ .Values.database.port }}...";
           until pg_isready -h {{ tpl .Values.database.host . }} -p {{ .Values.database.port }} -U {{ .Values.database.user }} -t 5;

--- a/phase-console/values.yaml
+++ b/phase-console/values.yaml
@@ -5,9 +5,9 @@ global:
   version: latest
   images:
     frontend:
-      repository: phasehq/frontend
+      repository: docker.io/phasehq/frontend
     backend:
-      repository: phasehq/backend
+      repository: docker.io/phasehq/backend
   external:
     enabled: false  # DEPRECATED: no longer used by the chart; use `database.external` and `redis.external` instead.
   # Examples:
@@ -144,7 +144,7 @@ database:
   # Path to CA certificate bundle for verifying database TLS certificate
   sslCaPath: ""
   image:
-    repository: postgres
+    repository: docker.io/library/postgres
     tag: 15.4-alpine3.17
   pullPolicy: IfNotPresent
   service:
@@ -174,7 +174,7 @@ redis:
   # Path to CA certificate bundle for Redis SSL verification
   sslCaPath: ""
   image:
-    repository: redis
+    repository: docker.io/library/redis
     tag: alpine3.19
   pullPolicy: IfNotPresent
   service:


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                             
                                                                                                                                                                                                                                       
  Init containers in the Phase Helm chart use hardcoded image references (`redis:alpine3.19`, `postgres:15.4-alpine3.17`) instead of the configurable values already available in `values.yaml`                                          
  (`redis.image.repository`/`redis.image.tag` and `database.image.repository`/`database.image.tag`).                                                                                                                                   
                                                                                                                                                                                                                                         
  This breaks deployments on container runtimes that enforce fully qualified image names, such as CRI-O with `shortNameMode: enforcing` (used by OKE, OpenShift, and other managed Kubernetes platforms).                                

  ## What changed

  Updated 4 hardcoded image references in init containers to use the existing `values.yaml` configuration:

  | File | Init container | Before | After |
  |---|---|---|---|
  | `_helpers.tpl` | `wait-for-migrations` | `postgres:15.4-alpine3.17` | `{{ .Values.database.image.repository }}:{{ .Values.database.image.tag }}` |
  | `job-migrations.yaml` | `wait-for-redis` | `redis:alpine3.19` | `{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}` |
  | `job-migrations.yaml` | `check-db-ready` | `postgres:15.4-alpine3.17` | `{{ .Values.database.image.repository }}:{{ .Values.database.image.tag }}` |
  | `deployment-worker.yaml` | `wait-for-redis` | `redis:alpine3.19` | `{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}` |

  No changes to `values.yaml` — the values already exist and are used by `deployment-postgres.yaml` and `deployment-redis.yaml`, but were not referenced by init containers.

  ## Why

  CRI-O with short name enforcement rejects unqualified images like `redis:alpine3.19` because they are ambiguous (could resolve to multiple registries). Users need to set `redis.image.repository: docker.io/redis` in their values,
  but the current templates ignore this for init containers.