### PR TITLE
Push :latest Docker tag on release instead of main push

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Build and push (Main branch)
         if: github.ref == 'refs/heads/main'
         run: |
-          docker buildx build --platform linux/amd64,linux/arm64 -t phasehq/kubernetes-operator:latest . --push
+          docker buildx build --platform linux/amd64,linux/arm64 -t phasehq/kubernetes-operator:main . --push
 
       - name: Build and push (Release tag)
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          docker buildx build --platform linux/amd64,linux/arm64 -t phasehq/kubernetes-operator:${{ steps.extract_tag.outputs.tag }} . --push
+          docker buildx build --platform linux/amd64,linux/arm64 -t phasehq/kubernetes-operator:${{ steps.extract_tag.outputs.tag }} -t phasehq/kubernetes-operator:latest . --push


### PR DESCRIPTION
## Summary
- Moves the `:latest` Docker tag from being pushed on every `main` branch push to only on `v*` release tags
- Main branch pushes now tag as `:main` instead
- Release tag pushes now push both `:<version>` and `:latest`

## Test plan
- [ ] Verify pushing to `main` produces a `:main` tagged image
- [ ] Verify pushing a `v*` tag produces both `:<version>` and `:latest` tagged images