### PR TITLE
fix: make PhaseSecret sync daemon async to avoid thread-pool starvation

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import kopf
 import logging
 import base64
@@ -16,20 +17,29 @@ from dateutil import parser
 logger = logging.getLogger(__name__)
 
 @kopf.daemon('secrets.phase.dev', 'v1alpha1', 'phasesecrets')
-def phase_secret_sync(spec, name, namespace, logger, uid, stopped, **kwargs):
+async def phase_secret_sync(spec, name, namespace, logger, uid, stopped, **kwargs):
     while not stopped:
         polling_interval = max(spec.get('pollingInterval', 60), 5)
-        
+
         try:
-            _phase_sync_secrets(spec, name, namespace, logger, uid, **kwargs)
+            # _phase_sync_secrets does blocking K8s/Phase API I/O. Offload it to a
+            # worker thread so the daemon coroutine itself never pins a pool thread
+            # for the whole pollingInterval. This keeps concurrency proportional to
+            # active sync work rather than to the total number of PhaseSecret CRs.
+            await asyncio.to_thread(
+                _phase_sync_secrets, spec, name, namespace, logger, uid, **kwargs
+            )
         except Exception as e:
             logger.error(
                 f"Unexpected error in daemon while syncing PhaseSecret {name} in namespace {namespace}: {e}"
             )
-        
-        # Wait for the next poll
-        if stopped.wait(polling_interval):
-            break
+
+        # Wait for the next poll without holding a thread pool slot. If the daemon
+        # is stopped while waiting, stopped.wait() resolves and the while-guard exits.
+        try:
+            await asyncio.wait_for(stopped.wait(), timeout=polling_interval)
+        except asyncio.TimeoutError:
+            pass
 
 def _phase_sync_secrets(spec, name, namespace, logger, uid, **kwargs):
     try:


### PR DESCRIPTION
## Summary

Fixes the silent reconcile starvation described in #50.

In v1.4.0+, `phase_secret_sync` is a **synchronous** `@kopf.daemon`. kopf runs sync daemons on a `ThreadPoolExecutor` whose default size is `min(32, os.cpu_count() + 4)`, and each daemon blocks one thread for its entire lifetime via `stopped.wait(pollingInterval)`. So the number of PhaseSecret CRs a single operator pod can ever reconcile is capped at the pool size. On a 4‑CPU node that's **8** — any CRs beyond the first N (alphabetically) never sync, with no error logs. v1.3.0 was unaffected because `@kopf.timer` did not pin a thread between firings.

## Change

Make the daemon `async`:

- Offload the blocking K8s/Phase I/O in `_phase_sync_secrets` via `asyncio.to_thread(...)`, so the inner call still runs off the event loop but only occupies a pool slot **while actively syncing** rather than for the whole `pollingInterval`.
- Replace the blocking `stopped.wait(timeout)` with `await asyncio.wait_for(stopped.wait(), timeout=pollingInterval)` so the idle wait does not hold a thread.

Concurrency now scales with active sync work instead of total CR count, so an operator can manage an arbitrary number of PhaseSecrets regardless of node CPU count, with no extra idle-thread memory cost.

This is an alternative to #47's `settings.execution.max_workers = 50`, which raises the ceiling but keeps one pinned thread per CR (re‑starves past 50 CRs and adds idle‑thread memory). The two approaches can also be combined.

## Testing

- `python -m py_compile src/main.py` passes.
- Independently reproduced the starvation on a 4‑CPU node (pool size 8) with 20+ PhaseSecret CRs: exactly 8 reconciled, the rest silent. With this patch all CRs reconcile.

Closes #50
