### PR TITLE
Add onSecretReferenceError policy and isolate managed-secret failures

### DIFF
--- a/api/v1alpha1/phasesecret_types.go
+++ b/api/v1alpha1/phasesecret_types.go
@@ -11,6 +11,7 @@ type PhaseSecretSpec struct {
 	PhaseAppEnv             string                   `json:"phaseAppEnv,omitempty"`
 	PhaseAppEnvPath         string                   `json:"phaseAppEnvPath,omitempty"`
 	PhaseAppEnvTag          string                   `json:"phaseAppEnvTag,omitempty"`
+	OnSecretReferenceError  string                   `json:"onSecretReferenceError,omitempty"`
 	Authentication          *Authentication          `json:"authentication,omitempty"`
 	PhaseHost               string                   `json:"phaseHost,omitempty"`
 	ManagedSecretReferences []ManagedSecretReference `json:"managedSecretReferences,omitempty"`

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -53,6 +53,7 @@ func main() {
 	}
 
 	reconciler := phasecontroller.NewPhaseSecretReconciler(mgr.GetClient(), mgr.GetScheme())
+	reconciler.Recorder = mgr.GetEventRecorderFor("phase-secret-controller")
 	reconciler.MaxConcurrentReconciles = intEnv("PHASE_OPERATOR_MAX_CONCURRENT_RECONCILES", reconciler.MaxConcurrentReconciles)
 	if err := reconciler.SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "unable to create PhaseSecret controller")

--- a/crd-template.yaml
+++ b/crd-template.yaml
@@ -53,6 +53,17 @@ spec:
                 phaseAppEnvTag:
                   description: Tag for filtering secrets in the specified Phase app environment.
                   type: string
+                onSecretReferenceError:
+                  description: >-
+                    Policy when a Phase secret reference cannot be resolved. "Fail" (default)
+                    aborts the sync so unresolved values are never written to the managed
+                    Secret. "Warn" syncs anyway — leaving references as their literal ${...}
+                    text — and records a Warning event naming the affected secrets.
+                  type: string
+                  enum:
+                    - Fail
+                    - Warn
+                  default: Fail
                 authentication:
                   type: object
                   properties:

--- a/internal/controller/phasesecret_controller.go
+++ b/internal/controller/phasesecret_controller.go
@@ -8,6 +8,9 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"regexp"
+	"sort"
+	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -17,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	crcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
@@ -29,22 +33,23 @@ import (
 )
 
 const (
-	defaultPhaseHost          = "https://console.phase.dev"
-	defaultPhaseAppEnv        = "production"
-	defaultPhaseAppEnvPath    = "/"
-	defaultPollingInterval    = 60 * time.Second
-	minPollingInterval        = 5 * time.Second
-	defaultServiceTokenName   = "phase-service-token"
-	defaultSecretType         = corev1.SecretTypeOpaque
-	defaultNameTransformer    = "upper_snake"
-	redeployAnnotation        = "secrets.phase.dev/redeploy"
-	redeployTimestamp         = "phase.autoredeploy.timestamp"
-	serviceTokenSecretDataKey = "token"
+	defaultPhaseHost           = "https://console.phase.dev"
+	defaultPhaseAppEnv         = "production"
+	defaultPhaseAppEnvPath     = "/"
+	defaultPollingInterval     = 60 * time.Second
+	minPollingInterval         = 5 * time.Second
+	defaultServiceTokenName    = "phase-service-token"
+	defaultSecretType          = corev1.SecretTypeOpaque
+	defaultNameTransformer     = "upper_snake"
+	redeployAnnotation         = "secrets.phase.dev/redeploy"
+	redeployTimestamp          = "phase.autoredeploy.timestamp"
+	serviceTokenSecretDataKey  = "token"
+	onSecretReferenceErrorWarn = "Warn"
 )
 
 type PhaseClient interface {
 	EnvironmentUpdatedAt(ctx context.Context, token, host, appName, appID, envName string) (time.Time, error)
-	GetSecrets(ctx context.Context, token, host, appName, appID, envName, path, tag string) (map[string]string, error)
+	GetSecrets(ctx context.Context, token, host, appName, appID, envName, path, tag string, failOnReferenceError bool) (map[string]string, error)
 }
 
 type PhaseSecretReconciler struct {
@@ -52,6 +57,7 @@ type PhaseSecretReconciler struct {
 	Scheme                  *runtime.Scheme
 	Phase                   PhaseClient
 	Cache                   *syncstate.Cache
+	Recorder                record.EventRecorder
 	JitterRatio             float64
 	MaxConcurrentReconciles int
 }
@@ -106,20 +112,35 @@ func (r *PhaseSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return result, nil
 	}
 
-	phaseSecrets, err := r.Phase.GetSecrets(ctx, token, effective.phaseHost, effective.phaseApp, effective.phaseAppID, effective.phaseAppEnv, effective.phaseAppEnvPath, effective.phaseAppEnvTag)
+	failOnReferenceError := !strings.EqualFold(ps.Spec.OnSecretReferenceError, onSecretReferenceErrorWarn)
+	phaseSecrets, err := r.Phase.GetSecrets(ctx, token, effective.phaseHost, effective.phaseApp, effective.phaseAppID, effective.phaseAppEnv, effective.phaseAppEnvPath, effective.phaseAppEnvTag, failOnReferenceError)
 	if err != nil {
 		logger.Error(err, "failed to fetch Phase secrets")
+		reason := "FetchFailed"
+		if isReferenceResolutionError(err) {
+			reason = "ReferenceResolutionFailed"
+		}
+		r.emitWarning(&ps, reason, err.Error())
 		return result, nil
 	}
+	// In Warn mode the fetch succeeds even when references cannot be resolved,
+	// leaving them as literal ${...} text. Surface that so the bypass is never silent.
+	if !failOnReferenceError {
+		if keys := unresolvedReferenceKeys(phaseSecrets); len(keys) > 0 {
+			r.emitWarning(&ps, "UnresolvedReferences",
+				fmt.Sprintf("%d Phase secret(s) contain references that could not be resolved and were synced as-is: %s", len(keys), strings.Join(keys, ", ")))
+		}
+	}
 
-	secretChanged := false
-	affectedSecretNames := make([]string, 0, len(ps.Spec.ManagedSecretReferences))
+	changedSecretNames := make([]string, 0, len(ps.Spec.ManagedSecretReferences))
+	var refErrs []error
 	for _, ref := range ps.Spec.ManagedSecretReferences {
 		secretName := ref.SecretName
 		if secretName == "" {
-			return result, fmt.Errorf("managedSecretReferences entry has empty secretName")
+			refErrs = append(refErrs, fmt.Errorf("managedSecretReferences entry has empty secretName"))
+			r.emitWarning(&ps, "InvalidManagedSecretReference", "a managedSecretReferences entry has an empty secretName")
+			continue
 		}
-		affectedSecretNames = append(affectedSecretNames, secretName)
 
 		secretNamespace := ref.SecretNamespace
 		if secretNamespace == "" {
@@ -134,30 +155,78 @@ func (r *PhaseSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			nameTransformer = defaultNameTransformer
 		}
 
+		// A failure on one managed reference must not block the others. Collect the
+		// error and continue; the checkpoint is held back below until every reference
+		// has synced, so failed references are retried on the next poll.
 		processed, err := transform.ProcessSecrets(phaseSecrets, ref.Processors, nameTransformer)
 		if err != nil {
-			return result, err
+			logger.Error(err, "failed to process managed secret", "secret", types.NamespacedName{Name: secretName, Namespace: secretNamespace})
+			r.emitWarning(&ps, "SecretProcessingFailed", fmt.Sprintf("%s/%s: %v", secretNamespace, secretName, err))
+			refErrs = append(refErrs, err)
+			continue
 		}
 		changed, err := r.upsertSecret(ctx, secretName, secretNamespace, secretType, processed, ref.Template)
 		if err != nil {
 			logger.Error(err, "failed to reconcile managed secret", "secret", types.NamespacedName{Name: secretName, Namespace: secretNamespace})
-			return result, nil
+			r.emitWarning(&ps, "SecretSyncFailed", fmt.Sprintf("%s/%s: %v", secretNamespace, secretName, err))
+			refErrs = append(refErrs, err)
+			continue
 		}
-		secretChanged = secretChanged || changed
+		if changed {
+			changedSecretNames = append(changedSecretNames, secretName)
+		}
 	}
 
-	if secretChanged {
-		if err := r.redeployAffectedDeployments(ctx, ps.Namespace, affectedSecretNames, ps.Spec.RedeployLabelSelector); err != nil {
+	// Only redeploy Deployments wired to secrets that actually changed this sync.
+	if len(changedSecretNames) > 0 {
+		if err := r.redeployAffectedDeployments(ctx, ps.Namespace, changedSecretNames, ps.Spec.RedeployLabelSelector); err != nil {
 			logger.Error(err, "failed to patch one or more affected deployments")
 		}
+	}
+
+	// Hold the sync checkpoint until every managed reference has synced, so the next
+	// poll retries the failures instead of treating the environment as fully synced.
+	if len(refErrs) > 0 {
+		logger.Info("PhaseSecret sync completed with errors; checkpoint not advanced",
+			"managedSecretCount", len(ps.Spec.ManagedSecretReferences), "failed", len(refErrs), "changed", len(changedSecretNames))
+		return result, nil
 	}
 
 	if err := r.Cache.Update(ps.Namespace, ps.Name, string(ps.UID), updatedAt, specHash); err != nil {
 		return result, err
 	}
 
-	logger.Info("PhaseSecret sync complete", "managedSecretCount", len(ps.Spec.ManagedSecretReferences), "secretChanged", secretChanged, "nextSyncAfter", requeueAfter.String())
+	logger.Info("PhaseSecret sync complete", "managedSecretCount", len(ps.Spec.ManagedSecretReferences), "changed", len(changedSecretNames), "nextSyncAfter", requeueAfter.String())
 	return result, nil
+}
+
+func (r *PhaseSecretReconciler) emitWarning(ps *phasev1.PhaseSecret, reason, message string) {
+	if r.Recorder != nil {
+		r.Recorder.Event(ps, corev1.EventTypeWarning, reason, message)
+	}
+}
+
+var referencePattern = regexp.MustCompile(`\$\{[^}]+\}`)
+
+func isReferenceResolutionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "resolve references") ||
+		strings.Contains(msg, "could not be resolved") ||
+		strings.Contains(msg, "referenced secrets")
+}
+
+func unresolvedReferenceKeys(secrets map[string]string) []string {
+	keys := make([]string, 0)
+	for key, value := range secrets {
+		if referencePattern.MatchString(value) {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func (r *PhaseSecretReconciler) serviceToken(ctx context.Context, ps *phasev1.PhaseSecret) (string, error) {

--- a/internal/controller/phasesecret_controller_test.go
+++ b/internal/controller/phasesecret_controller_test.go
@@ -33,7 +33,7 @@ func (f *fakePhaseClient) EnvironmentUpdatedAt(context.Context, string, string, 
 	return f.updatedAt, nil
 }
 
-func (f *fakePhaseClient) GetSecrets(context.Context, string, string, string, string, string, string, string) (map[string]string, error) {
+func (f *fakePhaseClient) GetSecrets(context.Context, string, string, string, string, string, string, string, bool) (map[string]string, error) {
 	f.getCalls++
 	return f.secrets, nil
 }
@@ -259,6 +259,46 @@ func TestRedeployLabelSelectorNarrowsDeploymentScan(t *testing.T) {
 	}
 }
 
+func TestReconcileContinuesPastFailingManagedReference(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+	ps := testPhaseSecret()
+	// The first reference fails to write; the second must still sync.
+	ps.Spec.ManagedSecretReferences = []phasev1.ManagedSecretReference{
+		{SecretName: "boom", SecretNamespace: "secrets-a", SecretType: string(corev1.SecretTypeOpaque)},
+		{SecretName: "good", SecretNamespace: "secrets-a", SecretType: string(corev1.SecretTypeOpaque)},
+	}
+	phase := &fakePhaseClient{
+		updatedAt: time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC),
+		secrets:   map[string]string{"API_KEY": "secret"},
+	}
+	base := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(&ps, tokenSecret("app-a", "phase-service-token")).Build()
+	k8sClient := &failingCreateClient{Client: base, failName: "boom"}
+	reconciler := testReconciler(k8sClient, scheme, phase, t.TempDir())
+
+	if _, err := reconciler.Reconcile(ctx, requestFor(ps)); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	var good corev1.Secret
+	if err := base.Get(ctx, types.NamespacedName{Name: "good", Namespace: "secrets-a"}, &good); err != nil {
+		t.Fatalf("second managed secret was blocked by the first failure: %v", err)
+	}
+	var boom corev1.Secret
+	if err := base.Get(ctx, types.NamespacedName{Name: "boom", Namespace: "secrets-a"}, &boom); err == nil {
+		t.Fatal("failing managed secret should not have been created")
+	}
+
+	// Checkpoint must not advance while a reference fails: the next poll re-fetches.
+	if _, err := reconciler.Reconcile(ctx, requestFor(ps)); err != nil {
+		t.Fatalf("second Reconcile() error = %v", err)
+	}
+	if phase.getCalls != 2 {
+		t.Fatalf("checkpoint should not advance while a reference fails; full fetches = %d, want 2", phase.getCalls)
+	}
+}
+
 func testScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	scheme := runtime.NewScheme()
@@ -283,6 +323,18 @@ func (c *failingUpdateClient) Update(context.Context, client.Object, ...client.U
 func (c *failingUpdateClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
 	c.deleteCalled = true
 	return c.Client.Delete(ctx, obj, opts...)
+}
+
+type failingCreateClient struct {
+	client.Client
+	failName string
+}
+
+func (c *failingCreateClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if obj.GetName() == c.failName {
+		return errors.New("create failed")
+	}
+	return c.Client.Create(ctx, obj, opts...)
 }
 
 func testReconciler(k8sClient client.Client, scheme *runtime.Scheme, phase *fakePhaseClient, dir string) *PhaseSecretReconciler {

--- a/internal/phase/client.go
+++ b/internal/phase/client.go
@@ -106,7 +106,7 @@ type appKeyTimestamps struct {
 	} `json:"apps"`
 }
 
-func (c *Client) GetSecrets(ctx context.Context, token, host, appName, appID, envName, path, tag string) (map[string]string, error) {
+func (c *Client) GetSecrets(ctx context.Context, token, host, appName, appID, envName, path, tag string, failOnReferenceError bool) (map[string]string, error) {
 	result := map[string]string{}
 	err := c.withRetry(ctx, func() error {
 		p, err := phasesdk.New(token, host, c.debug)
@@ -120,7 +120,7 @@ func (c *Client) GetSecrets(ctx context.Context, token, host, appName, appID, en
 			EnvName:                        envName,
 			Path:                           path,
 			Tag:                            tag,
-			FailOnReferenceResolutionError: true,
+			FailOnReferenceResolutionError: failOnReferenceError,
 		})
 		if err != nil {
 			return err

--- a/phase-kubernetes-operator/crds/crd-template.yaml
+++ b/phase-kubernetes-operator/crds/crd-template.yaml
@@ -53,6 +53,17 @@ spec:
                 phaseAppEnvTag:
                   description: Tag for filtering secrets in the specified Phase app environment.
                   type: string
+                onSecretReferenceError:
+                  description: >-
+                    Policy when a Phase secret reference cannot be resolved. "Fail" (default)
+                    aborts the sync so unresolved values are never written to the managed
+                    Secret. "Warn" syncs anyway — leaving references as their literal ${...}
+                    text — and records a Warning event naming the affected secrets.
+                  type: string
+                  enum:
+                    - Fail
+                    - Warn
+                  default: Fail
                 authentication:
                   type: object
                   properties:


### PR DESCRIPTION
## Summary

Closes two ways a single problem could silently break secret delivery, both surfaced during QA of the Go operator.

### 1. Unresolved secret references no longer fail an environment invisibly
The operator hardcoded the SDK's `FailOnReferenceResolutionError: true`, so one unresolvable `${REF}` anywhere in the source env aborted the **whole** sync — with no signal on the `PhaseSecret` (no status is written, no event was emitted; the error lived only in pod logs).

New `spec.onSecretReferenceError` enum:
- **`Fail`** (default) — abort the sync; never write unresolved values. Emits `Warning ReferenceResolutionFailed` naming the reference.
- **`Warn`** — sync anyway, leaving references as literal `${...}`. Emits `Warning UnresolvedReferences` listing the affected secrets, so the bypass is never silent.

Fail-closed stays the default (don't hand a broken value to a workload), but it's now **visible** via `kubectl describe phasesecret` and overridable per-CR.

### 2. A failing managedSecretReference no longer blocks the others
Previously the reconcile `return`ed on the first upsert/process error, so a single poison-pill reference (e.g. an immutable secret-type change) silently blocked every later reference in the same CR, indefinitely. Now each reference is processed independently:
- collect errors and continue;
- hold the sync checkpoint until all references succeed (failures retry next poll);
- redeploy only the secrets that actually changed;
- emit a `Warning SecretSyncFailed` / `SecretProcessingFailed` event per failing reference.

## API

```yaml
spec:
  onSecretReferenceError: Fail   # default; or "Warn"
```

## Testing

- `go build` / `go vet` / `go test ./...` green, incl. new `TestReconcileContinuesPastFailingManagedReference`.
- Verified live on minikube against a real Phase env containing an unresolvable `${DB_NAME}`:
  - **Fail**: secret not written; `Warning ReferenceResolutionFailed … ${DB_NAME} could not be resolved …` on the CR.
  - **Warn**: all 21 secrets synced with `…:5432/${DB_NAME}` literal; `Warning UnresolvedReferences … POSTGRES_CONNECTION_STRING`.
  - **Multi-ref** `[good, poison(tls), good]`: the trailing good ref is now created (previously stuck `NotFound`); poison ref preserved + `SecretSyncFailed` event; checkpoint held for retry.

## Notes / follow-ups
- Reference-error detection is string-based (the SDK doesn't export a typed error); a typed error upstream would be cleaner.
- Status uses **Events** only; a `.status.conditions` entry is a natural follow-up (would need a `phasesecrets/status` RBAC rule).
- Docs: `onSecretReferenceError` should be documented, and strict-by-default reference handling called out as a v1→v2 behavior change in the upgrade notes.